### PR TITLE
Fix: Adjust drought impact in population model

### DIFF
--- a/insect_population_model.py
+++ b/insect_population_model.py
@@ -23,7 +23,7 @@ def simulate_population(initial_population, growth_rate, carrying_capacity, num_
 
         # Apply drought impact
         # BUG: This drought impact logic is flawed and can lead to overestimation.
-        drought_effect = 1 + (drought_intensity * 0.5) # This is the problematic line
+        drought_effect = 1 - (drought_intensity * 0.5) # Adjusted to reflect negative impact
         next_population *= drought_effect
 
         population.append(int(max(0, next_population)))


### PR DESCRIPTION
This pull request addresses the bug reported in #1 by adjusting the drought impact logic in the `simulate_population` function. The previous implementation incorrectly increased population during drought; this fix changes the `drought_effect` calculation to reflect a negative impact.